### PR TITLE
Use uppercase for the user names to avoid conflicts with Playfab user registration.

### DIFF
--- a/Source/Services/RPSLS.Game.Api/GrpcServices/MultiplayerGameManagerService.cs
+++ b/Source/Services/RPSLS.Game.Api/GrpcServices/MultiplayerGameManagerService.cs
@@ -210,7 +210,8 @@ namespace RPSLS.Game.Api.GrpcServices
             return result;
         }
 
-        private static string GetUsername(string username, bool twitterLogged) => twitterLogged ? username : $"${username}";
+        private static string GetUsername(string username, bool twitterLogged) 
+            => twitterLogged ? username.ToUpperInvariant() : $"${username.ToUpperInvariant()}";
 
         private static string GetUserDisplay(string username) => 
             string.IsNullOrWhiteSpace(username) ? "-" :

--- a/Source/Services/RPSLS.Game.Multiplayer/Services/PlayFabService.cs
+++ b/Source/Services/RPSLS.Game.Multiplayer/Services/PlayFabService.cs
@@ -128,7 +128,7 @@ namespace RPSLS.Game.Multiplayer.Services
             var loginResult = await Call(
                 PlayFabClientAPI.LoginWithCustomIDAsync,
                 new LoginWithCustomIDRequestBuilder()
-                    .WithUser(username.ToUpper())
+                    .WithUser(username.ToUpperInvariant())
                     .WithAccountInfo()
                     .CreateIfDoesntExist());
 
@@ -187,7 +187,7 @@ namespace RPSLS.Game.Multiplayer.Services
                 await Call(
                     PlayFabClientAPI.UpdateUserTitleDisplayNameAsync,
                     new UpdateUserTitleDisplayNameRequestBuilder()
-                        .WithName(username));
+                        .WithName(username.ToUpperInvariant()));
             }
 
             return userEntity;

--- a/Source/Services/RPSLS.Game.Multiplayer/Services/PlayFabService.cs
+++ b/Source/Services/RPSLS.Game.Multiplayer/Services/PlayFabService.cs
@@ -128,7 +128,7 @@ namespace RPSLS.Game.Multiplayer.Services
             var loginResult = await Call(
                 PlayFabClientAPI.LoginWithCustomIDAsync,
                 new LoginWithCustomIDRequestBuilder()
-                    .WithUser(username)
+                    .WithUser(username.ToUpper())
                     .WithAccountInfo()
                     .CreateIfDoesntExist());
 
@@ -176,7 +176,7 @@ namespace RPSLS.Game.Multiplayer.Services
             var loginResult = await Call(
                 PlayFabClientAPI.LoginWithCustomIDAsync,
                 new LoginWithCustomIDRequestBuilder()
-                    .WithUser(username)
+                    .WithUser(username.ToUpperInvariant())
                     .WithAccountInfo()
                     .CreateIfDoesntExist());
 
@@ -251,7 +251,7 @@ namespace RPSLS.Game.Multiplayer.Services
             if (apiError != null)
             {
                 var detailedError = PlayFabUtil.GenerateErrorReport(apiError);
-                _logger.LogWarning($"Something went wrong with PlayFab API call {playFabCall.Method.Name}.{Environment.NewLine}{detailedError}");
+                _logger.LogError($"Something went wrong with PlayFab API call {playFabCall.Method.Name}.{Environment.NewLine}{detailedError}");
             }
 
             return taskResult;


### PR DESCRIPTION
Use uppercase for the user names to avoid conflicts in the Playfab registration of the players. As an example, Playfab considers Dsr and DSR as different user names, and allows to register both. But for the display name of those players Dsr and DSR are considered the same name and Playfab throws error by invalid name conflict. This