### PR TITLE
Fix problem  when entity token expires. Playfab SDK stores the token …

### DIFF
--- a/Source/Services/RPSLS.Game.Multiplayer/Config/MultiplayerSettings.cs
+++ b/Source/Services/RPSLS.Game.Multiplayer/Config/MultiplayerSettings.cs
@@ -10,5 +10,6 @@
         public TokenSettings Token { get; set; } = new TokenSettings();
         public int GameStatusUpdateDelay { get; set; } = 1000;
         public int GameStatusMaxWait { get; set; } = 60;
+        public int EntityTokenExpirationMinutes { get; set; } = 60;
     }
 }

--- a/Source/Services/RPSLS.Game.Multiplayer/Models/Token.cs
+++ b/Source/Services/RPSLS.Game.Multiplayer/Models/Token.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace RPSLS.Game.Multiplayer.Models
+{
+    public class Token
+    {
+        private readonly int _maxTokenLifeMinutes;
+        private readonly DateTime _creationTimeStamp;
+
+        public Token(string value, int maxTokenLifeMinutes)
+        {
+            Value = value;
+            _maxTokenLifeMinutes = maxTokenLifeMinutes;
+            _creationTimeStamp = DateTime.UtcNow;
+        }
+
+        public string Value { get; private set; }
+
+        public bool IsExpired
+        {
+            get
+            {
+                var tokenLife = DateTime.UtcNow.Subtract(_creationTimeStamp);
+                return tokenLife.Minutes > _maxTokenLifeMinutes;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix problem  when entity token expires. Playfab SDK stores the token and it is needed to call PlayFabAuthenticationAPI.ForgetAllCredentials(). In addition now a new token is requested every hour, and not for every call to the service.